### PR TITLE
Fix Incomplete JSON Blob Export

### DIFF
--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -269,6 +269,8 @@ class ExportJson extends ExportPlugin
                 if ($fieldsMeta[$i]->type === 'geometry') {
                     // export GIS types as hex
                     $record[$i] = '0x' . bin2hex($record[$i]);
+                } elseif (strpos($fields_meta[$i]->type,'blob') !== false) {
+                    $record[$i] = base64_encode($record[$i]);
                 }
                 $data[$columns[$i]] = $record[$i];
             }


### PR DESCRIPTION
Apply base64_encode when exporting table that contains blob column

Signed-off-by: Andreas Kurniawan <andreas@kurniawan.ceo>